### PR TITLE
Fix DBLP hit parsing and IEEE results extraction

### DIFF
--- a/labelpilot/src/adapters/ieee-adapter.ts
+++ b/labelpilot/src/adapters/ieee-adapter.ts
@@ -249,7 +249,7 @@ export class IeeeAdapter implements SiteAdapter {
     const papers: PaperInfo[] = []
     
     // Search results page: xpl-results-item elements
-    const searchResults = document.querySelectorAll('xpl-results-item, .List-results-items')
+    const searchResults = document.querySelectorAll('xpl-results-item')
     if (searchResults.length > 0) {
       searchResults.forEach((element, index) => {
         const paper = this.processSearchResultItem(element as HTMLElement, index)
@@ -258,6 +258,25 @@ export class IeeeAdapter implements SiteAdapter {
         }
       })
       return papers
+    }
+
+    // Search results container: List-results-items (process child items)
+    const listContainers = document.querySelectorAll('.List-results-items')
+    if (listContainers.length > 0) {
+      listContainers.forEach((container) => {
+        const items = container.querySelectorAll('xpl-results-item, .result-item, .document-result')
+        items.forEach((element, index) => {
+          const paper = element.tagName.toLowerCase() === 'xpl-results-item'
+            ? this.processSearchResultItem(element as HTMLElement, index)
+            : this.processResultItem(element as HTMLElement, index)
+          if (paper) {
+            papers.push(paper)
+          }
+        })
+      })
+      if (papers.length > 0) {
+        return papers
+      }
     }
 
     // Alternative search results structure

--- a/labelpilot/src/services/dblp-service.ts
+++ b/labelpilot/src/services/dblp-service.ts
@@ -39,7 +39,7 @@ interface DblpApiResponse {
   result: {
     hits: {
       '@total': string
-      hit?: DblpHit[]
+      hit?: DblpHit[] | DblpHit
     }
   }
 }
@@ -214,9 +214,10 @@ export class DblpService {
    * Parse DBLP API response and find the best matching paper
    */
   private parseResponse(data: DblpApiResponse, searchTitle: string): DblpResult {
-    const hits = data.result?.hits?.hit
-    
-    if (!hits || hits.length === 0) {
+    const rawHits = data.result?.hits?.hit
+    const hits = Array.isArray(rawHits) ? rawHits : rawHits ? [rawHits] : []
+
+    if (hits.length === 0) {
       return {
         found: false,
         venue: null,


### PR DESCRIPTION
### Motivation
- The DBLP API sometimes returns a single `hit` object instead of an array, which could break parsing logic that expected an array.  
- The IEEE results page may present a container element (`.List-results-items`) holding multiple result items, and the previous selector could treat the container as a single paper.  
- These issues cause missed matches or incorrect parsing when extracting paper metadata and venues.  

### Description
- Updated the `DblpApiResponse` `hit` type to `DblpHit[] | DblpHit` and normalized `rawHits` into an array in `parseResponse` so single-hit responses are handled safely.  
- Changed `parseResponse` to treat single-object `hit` values as a one-element array before further processing.  
- Adjusted `IeeeAdapter.getPapers()` to stop querying `xpl-results-item` and `.List-results-items` together, and added logic to iterate `.List-results-items` containers and process their child items (`xpl-results-item`, `.result-item`, `.document-result`) individually.  
- Commit message: `Fix DBLP parsing and IEEE results handling` (changes applied to `src/services/dblp-service.ts` and `src/adapters/ieee-adapter.ts`).  

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6953c9199e408325a2c58ad073a258dd)